### PR TITLE
fix: default jdk provider link path can now be set

### DIFF
--- a/src/main/java/dev/jbang/devkitman/JdkManager.java
+++ b/src/main/java/dev/jbang/devkitman/JdkManager.java
@@ -30,9 +30,13 @@ public class JdkManager {
 
 	private final JdkProvider defaultProvider;
 
+	/**
+	 * Creates a JDK manager that is configured exactly like the one used by JBang.
+	 */
 	public static JdkManager create() {
 		Path installPath = JBangJdkProvider.getJBangJdkDir();
 		JdkDiscovery.Config cfg = new JdkDiscovery.Config(installPath);
+		cfg.properties.put("link", JBangJdkProvider.getJBangConfigDir().resolve("currentjdk").toString());
 		return builder().providers(JdkProviders.instance().all(cfg)).build();
 	}
 

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
@@ -2,6 +2,7 @@ package dev.jbang.devkitman.jdkproviders;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -81,7 +82,9 @@ public class DefaultJdkProvider extends BaseJdkProvider {
 
 		@Override
 		public JdkProvider create(Config config) {
-			return new DefaultJdkProvider(config.installPath.resolve(PROVIDER_ID));
+			String defaultLink = config.properties.computeIfAbsent("link",
+					k -> config.installPath.resolve(PROVIDER_ID).toString());
+			return new DefaultJdkProvider(Paths.get(defaultLink));
 		}
 	}
 }

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/JBangJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/JBangJdkProvider.java
@@ -145,7 +145,7 @@ public class JBangJdkProvider extends BaseFoldersJdkProvider
 		return dir;
 	}
 
-	private static Path getJBangConfigDir() {
+	public static Path getJBangConfigDir() {
 		Path dir;
 		String jd = System.getenv("JBANG_DIR");
 		if (jd != null) {


### PR DESCRIPTION
And `JdkManager.create()` now uses that to configure a manager that is as close to the one used by JBang itself.