### PR TITLE
chore: minor changes

### DIFF
--- a/samples/listinstalled.java
+++ b/samples/listinstalled.java
@@ -6,6 +6,6 @@ import dev.jbang.devkitman.*;
 class listinstalled {
 	public static void main(String[] args) {
 		JdkManager jdkManager = JdkManager.create();
-		System.out.println("Installed: " + jdkManager.listInstalledJdks());
+		jdkManager.listInstalledJdks().forEach(System.out::println);
 	}
 }

--- a/src/main/java/dev/jbang/devkitman/Jdk.java
+++ b/src/main/java/dev/jbang/devkitman/Jdk.java
@@ -175,7 +175,7 @@ public interface Jdk extends Comparable<Jdk> {
 
 		@Override
 		public String toString() {
-			return majorVersion() + " (" + version + (isFixedVersion() ? " (fixed)" : " (dynamic)") + ", " + id + ", "
+			return majorVersion() + " (" + version + (isFixedVersion() ? " [fixed]" : " [dynamic]") + ", " + id + ", "
 					+ home + ")";
 		}
 	}

--- a/src/main/java/dev/jbang/devkitman/JdkManager.java
+++ b/src/main/java/dev/jbang/devkitman/JdkManager.java
@@ -538,7 +538,7 @@ public class JdkManager {
 	}
 
 	public List<Jdk> listInstalledJdks() {
-		return listInstalledJdks(JdkProvider.Predicates.all).sorted().collect(Collectors.toList());
+		return listInstalledJdks(JdkProvider.Predicates.all).collect(Collectors.toList());
 	}
 
 	private Stream<Jdk> listInstalledJdks(Predicate<JdkProvider> providerFilter) {


### PR DESCRIPTION
Don't sort listInstalled() output anymore and improve the output format of Jdk.toString() and the listinstalled sample.