### PR TITLE
feat: added new "multi home" provider

### DIFF
--- a/src/main/java/dev/jbang/devkitman/jdkproviders/JavaHomeJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/JavaHomeJdkProvider.java
@@ -14,8 +14,7 @@ import dev.jbang.devkitman.util.JavaUtils;
 
 /**
  * This JDK provider detects if a JDK is already available on the system by
- * looking at <code>
- * JAVA_HOME</code> environment variable.
+ * looking at <code>JAVA_HOME</code> environment variable.
  */
 public class JavaHomeJdkProvider extends BaseJdkProvider {
 

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/MultiHomeJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/MultiHomeJdkProvider.java
@@ -1,0 +1,62 @@
+package dev.jbang.devkitman.jdkproviders;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import org.jspecify.annotations.NonNull;
+
+import dev.jbang.devkitman.Jdk;
+import dev.jbang.devkitman.JdkDiscovery;
+import dev.jbang.devkitman.JdkProvider;
+
+/**
+ * This JDK provider detects if JDKs are already available on the system by
+ * looking at any environment variables that start with <code>JAVA_HOME_</code>.
+ * This is used for example in GitHub actions where multiple JDKs can be
+ * installed using the setup-java action.
+ */
+public class MultiHomeJdkProvider extends BaseJdkProvider {
+
+	@Override
+	@NonNull
+	public String name() {
+		return Discovery.PROVIDER_ID;
+	}
+
+	@Override
+	public @NonNull String description() {
+		return "JDKs pointed to by any environment variable starting with JAVA_HOME_";
+	}
+
+	@NonNull
+	@Override
+	public List<Jdk> listInstalled() {
+		return System.getenv()
+			.entrySet()
+			.stream()
+			.filter(entry -> entry.getKey().startsWith("JAVA_HOME_"))
+			.map(entry -> Paths.get(entry.getValue()))
+			.filter(Files::isDirectory)
+			.map(jdkHome -> createJdk(Discovery.PROVIDER_ID, jdkHome, null, false))
+			.filter(Objects::nonNull)
+			.collect(Collectors.toList());
+	}
+
+	public static class Discovery implements JdkDiscovery {
+		public static final String PROVIDER_ID = "multihome";
+
+		@Override
+		@NonNull
+		public String name() {
+			return PROVIDER_ID;
+		}
+
+		@Override
+		public JdkProvider create(Config config) {
+			return new MultiHomeJdkProvider();
+		}
+	}
+}

--- a/src/main/resources/META-INF/services/dev.jbang.devkitman.JdkDiscovery
+++ b/src/main/resources/META-INF/services/dev.jbang.devkitman.JdkDiscovery
@@ -5,7 +5,8 @@ dev.jbang.devkitman.jdkproviders.PathJdkProvider$Discovery
 dev.jbang.devkitman.jdkproviders.LinkedJdkProvider$Discovery
 dev.jbang.devkitman.jdkproviders.JBangJdkProvider$Discovery
 dev.jbang.devkitman.jdkproviders.LinuxJdkProvider$Discovery
+dev.jbang.devkitman.jdkproviders.MiseJdkProvider$Discovery
+dev.jbang.devkitman.jdkproviders.MultiHomeJdkProvider$Discovery
 dev.jbang.devkitman.jdkproviders.ScoopJdkProvider$Discovery
 dev.jbang.devkitman.jdkproviders.SdkmanJdkProvider$Discovery
-dev.jbang.devkitman.jdkproviders.MiseJdkProvider$Discovery
 

--- a/src/test/java/dev/jbang/devkitman/BaseTest.java
+++ b/src/test/java/dev/jbang/devkitman/BaseTest.java
@@ -115,6 +115,13 @@ public class BaseTest {
 		return jdkPath;
 	}
 
+	protected Path createMockJdkExt(int jdkVersion) {
+		Path jdkPath = config.cachePath.resolve("jdk" + jdkVersion);
+		FileUtils.mkdirs(jdkPath);
+		initMockJdkDir(jdkPath, jdkVersion + ".0.7");
+		return jdkPath;
+	}
+
 	protected void initMockJdkDirRuntime(Path jdkPath, String version) {
 		initMockJdkDir(jdkPath, version, "JAVA_RUNTIME_VERSION", true, false, false, false);
 	}

--- a/src/test/java/dev/jbang/devkitman/TestJdkProviders.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkProviders.java
@@ -35,6 +35,7 @@ public class TestJdkProviders extends BaseTest {
 						"jbang",
 						"linux",
 						"mise",
+						"multihome",
 						"scoop",
 						"sdkman"));
 	}
@@ -75,6 +76,7 @@ public class TestJdkProviders extends BaseTest {
 						instanceOf(JBangJdkProvider.class),
 						instanceOf(LinuxJdkProvider.class),
 						instanceOf(MiseJdkProvider.class),
+						instanceOf(MultiHomeJdkProvider.class),
 						instanceOf(ScoopJdkProvider.class),
 						instanceOf(SdkmanJdkProvider.class)));
 	}


### PR DESCRIPTION
This looks at the existence of environment variables that have a name that starts with `JAVA_HOME_` and checks if they are pointing to a valid JDK installation.

Fixes #50