### PR TITLE
fix: `linkToExistingJdk()` now behaves as before

### DIFF
--- a/src/main/java/dev/jbang/devkitman/JdkManager.java
+++ b/src/main/java/dev/jbang/devkitman/JdkManager.java
@@ -485,7 +485,10 @@ public class JdkManager {
 	public void linkToExistingJdk(Path jdkPath, String id) {
 		JdkProvider linked = provider(LinkedJdkProvider.Discovery.PROVIDER_ID);
 		if (linked == null) {
-			return;
+			throw new IllegalStateException("No provider available to link JDK");
+		}
+		if (JavaUtils.parseToInt(id, 0) == 0) {
+			throw new IllegalArgumentException("Invalid JDK id: " + id + ", must be a valid major version number");
 		}
 		if (!Files.isDirectory(jdkPath)) {
 			throw new IllegalArgumentException("Unable to resolve path as directory: " + jdkPath);
@@ -493,6 +496,10 @@ public class JdkManager {
 		Jdk linkedJdk = linked.getAvailableByIdOrToken(id + "@" + jdkPath);
 		if (linkedJdk == null) {
 			throw new IllegalArgumentException("Unable to create link to JDK in path: " + jdkPath);
+		}
+		if (linkedJdk.majorVersion() != JavaUtils.parseToInt(id, 0)) {
+			throw new IllegalArgumentException(
+					"Linked JDK is not of the correct version: " + linkedJdk.majorVersion() + " instead of: " + id);
 		}
 		LOGGER.log(Level.FINE, "Linking JDK: {0} to {1}", new Object[] { id, jdkPath });
 		linked.install(linkedJdk);

--- a/src/test/java/dev/jbang/devkitman/TestJdkManager.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkManager.java
@@ -261,6 +261,32 @@ public class TestJdkManager extends BaseTest {
 	}
 
 	@Test
+	void testLinkToInvalidVersion() {
+		try {
+			Path jdkPath = createMockJdkExt(12);
+			jdkManager().linkToExistingJdk(jdkPath, "11");
+			assertThat("Should have thrown an exception", false);
+		} catch (IllegalArgumentException ex) {
+			assertThat(
+					ex.getMessage(),
+					startsWith("Linked JDK is not of the correct version: 12 instead of: 11"));
+		}
+	}
+
+	@Test
+	void testLinkToInvalidId() {
+		try {
+			Path jdkPath = createMockJdkExt(12);
+			jdkManager().linkToExistingJdk(jdkPath, "11foo");
+			assertThat("Should have thrown an exception", false);
+		} catch (IllegalArgumentException ex) {
+			assertThat(
+					ex.getMessage(),
+					startsWith("Invalid JDK id: 11foo, must be a valid major version number"));
+		}
+	}
+
+	@Test
 	void testProviderOrder() {
 		Arrays.asList(11, 12, 13).forEach(this::createMockJdk);
 


### PR DESCRIPTION
Fixes #55