### PR TITLE
Fix foojay

### DIFF
--- a/src/main/java/dev/jbang/devkitman/Jdk.java
+++ b/src/main/java/dev/jbang/devkitman/Jdk.java
@@ -200,6 +200,14 @@ public interface Jdk extends Comparable<Jdk> {
 				} else if (JavaUtils.hasJavaCmd(home)) {
 					tags.add(Jdk.Default.Tags.Jre.name());
 				}
+				Optional<String> version = JavaUtils.resolveJavaVersionStringFromPath(home);
+				if (version.isPresent()) {
+					if (version.get().matches(".*\\b(ea|EA)\\b.*")) {
+						tags.add(Jdk.Default.Tags.Ea.name());
+					} else {
+						tags.add(Jdk.Default.Tags.Ga.name());
+					}
+				}
 				Optional<String> graalVersion = JavaUtils.readGraalVMVersionStringFromReleaseFile(home);
 				if (graalVersion.isPresent()) {
 					tags.add(Jdk.Default.Tags.Graalvm.name());
@@ -227,8 +235,8 @@ public interface Jdk extends Comparable<Jdk> {
 		@NonNull
 		protected final Set<String> tags;
 
-		enum Tags {
-			Jre, Jdk, Graalvm, Native, Javafx
+		public enum Tags {
+			Jre, Jdk, Graalvm, Native, Javafx, Ea, Ga
 		}
 
 		Default(

--- a/src/main/java/dev/jbang/devkitman/Jdk.java
+++ b/src/main/java/dev/jbang/devkitman/Jdk.java
@@ -1,5 +1,6 @@
 package dev.jbang.devkitman;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Predicate;
@@ -30,18 +31,6 @@ public interface Jdk extends Comparable<Jdk> {
 	String version();
 
 	/**
-	 * Determines if the JDK version is fixed or that it can change
-	 */
-	boolean isFixedVersion();
-
-	/**
-	 * The path to where the JDK is installed. Can be <code>null</code> which means
-	 * the JDK isn't currently installed by that provider
-	 */
-	@NonNull
-	Path home();
-
-	/**
 	 * Returns the tags that are associated with this JDK
 	 */
 	@NonNull
@@ -50,40 +39,193 @@ public interface Jdk extends Comparable<Jdk> {
 	/**
 	 * Returns the major version of the JDK
 	 */
-	int majorVersion();
-
-	/**
-	 * Installs the JDK if it isn't already installed. If already installed it will
-	 * simply return the current object, if not it will return a new copy with
-	 * updated information (e.g. the home path will be set)
-	 * 
-	 * @return A <code>Jdk</code> object
-	 */
-	@NonNull
-	Jdk install();
-
-	/**
-	 * Uninstalls the JDK. If the JDK isn't installed it will do nothing
-	 */
-	void uninstall();
+	default int majorVersion() {
+		return JavaUtils.parseJavaVersion(version());
+	}
 
 	/**
 	 * Determines if this JDK is currently installed
 	 */
 	boolean isInstalled();
 
-	class Default implements Jdk {
+	interface AvailableJdk extends Jdk {
+
+		@Override
+		default boolean isInstalled() {
+			return false;
+		}
+
+		/**
+		 * Installs the JDK if it isn't already installed. If already installed it will
+		 * simply return the current object, if not it will return a new copy with
+		 * updated information (e.g. the home path will be set)
+		 *
+		 * @return A <code>Jdk</code> object
+		 */
 		@NonNull
-		private final transient JdkProvider provider;
+		InstalledJdk install();
+
+		class Default extends Jdk.Default implements AvailableJdk {
+
+			public Default(
+					@NonNull JdkProvider provider,
+					@NonNull String id,
+					@NonNull String version,
+					@Nullable Set<String> tags) {
+				super(provider, id, version, tags);
+			}
+
+			@Override
+			@NonNull
+			public InstalledJdk install() {
+				if (!provider.canUpdate()) {
+					throw new UnsupportedOperationException(
+							"Installing a JDK is not supported by " + provider);
+				}
+				return provider.install(this);
+			}
+
+			@Override
+			public String toString() {
+				return majorVersion() + " (" + version + ", " + id + ", " + ", " + tags + "))";
+			}
+		}
+	}
+
+	interface InstalledJdk extends Jdk {
+
+		/**
+		 * The path to where the JDK is installed. Can be <code>null</code> which means
+		 * the JDK isn't currently installed by that provider
+		 */
 		@NonNull
-		private final String id;
+		Path home();
+
+		/**
+		 * Determines if the JDK version is fixed or that it can change
+		 */
+		boolean isFixedVersion();
+
+		@Override
+		default boolean isInstalled() {
+			return true;
+		}
+
+		/**
+		 * Uninstalls the JDK. If the JDK isn't installed it will do nothing
+		 */
+		void uninstall();
+
+		class Default extends Jdk.Default implements InstalledJdk {
+			private final boolean fixedVersion;
+			@Nullable
+			private final Path home;
+
+			enum Tags {
+				Jre, Jdk, Graalvm, Native, Javafx
+			}
+
+			public Default(
+					@NonNull JdkProvider provider,
+					@NonNull String id,
+					@Nullable Path home,
+					@NonNull String version,
+					boolean fixedVersion,
+					@Nullable Set<String> tags) {
+				super(provider, id, version, tags != null ? tags : determineTagsFromJdkHome(home));
+				this.fixedVersion = fixedVersion;
+				this.home = home;
+			}
+
+			@Override
+			public boolean isFixedVersion() {
+				return fixedVersion;
+			}
+
+			@Override
+			@NonNull
+			public Path home() {
+				if (home == null) {
+					throw new IllegalStateException(
+							"Trying to retrieve home folder for uninstalled JDK");
+				}
+				return home;
+			}
+
+			@Override
+			public void uninstall() {
+				provider.uninstall(this);
+			}
+
+			@Override
+			public boolean isInstalled() {
+				return home != null;
+			}
+
+			@Override
+			public boolean equals(Object o) {
+				if (this == o)
+					return true;
+				if (o == null || getClass() != o.getClass())
+					return false;
+				InstalledJdk.Default jdk = (InstalledJdk.Default) o;
+				return id.equals(jdk.id) && Objects.equals(home, jdk.home);
+			}
+
+			@Override
+			public int hashCode() {
+				return Objects.hash(home, id);
+			}
+
+			@Override
+			public int compareTo(Jdk o) {
+				return Integer.compare(majorVersion(), o.majorVersion());
+			}
+
+			@Override
+			public String toString() {
+				return majorVersion() + " (" + version + (isFixedVersion() ? " [fixed]" : " [dynamic]") + ", " + id
+						+ ", "
+						+ home + ", " + tags + "))";
+			}
+
+			@NonNull
+			public static Set<String> determineTagsFromJdkHome(@Nullable Path home) {
+				if (home == null) {
+					return Collections.emptySet();
+				}
+				Set<String> tags = new HashSet<>();
+				if (JavaUtils.hasJavacCmd(home)) {
+					tags.add(Jdk.Default.Tags.Jdk.name());
+				} else if (JavaUtils.hasJavaCmd(home)) {
+					tags.add(Jdk.Default.Tags.Jre.name());
+				}
+				Optional<String> graalVersion = JavaUtils.readGraalVMVersionStringFromReleaseFile(home);
+				if (graalVersion.isPresent()) {
+					tags.add(Jdk.Default.Tags.Graalvm.name());
+					if (JavaUtils.hasNativeImageCmd(home)) {
+						tags.add(Jdk.Default.Tags.Native.name());
+					}
+				}
+				Path javafxProps = home.resolve("lib").resolve("javafx.properties");
+				if (Files.exists(javafxProps)) {
+					tags.add(Jdk.Default.Tags.Javafx.name());
+				}
+				return tags;
+			}
+		}
+
+	}
+
+	abstract class Default implements Jdk {
 		@NonNull
-		private final String version;
-		private final boolean fixedVersion;
-		@Nullable
-		private final Path home;
+		protected final transient JdkProvider provider;
 		@NonNull
-		private final Set<String> tags;
+		protected final String id;
+		@NonNull
+		protected final String version;
+		@NonNull
+		protected final Set<String> tags;
 
 		enum Tags {
 			Jre, Jdk, Graalvm, Native, Javafx
@@ -92,17 +234,15 @@ public interface Jdk extends Comparable<Jdk> {
 		Default(
 				@NonNull JdkProvider provider,
 				@NonNull String id,
-				@Nullable Path home,
 				@NonNull String version,
-				boolean fixedVersion,
-				@NonNull Set<String> tags) {
+				@Nullable Set<String> tags) {
 			this.provider = provider;
 			this.id = id;
 			this.version = version;
-			this.fixedVersion = fixedVersion;
-			this.home = home;
 			TreeSet<String> ts = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-			ts.addAll(tags);
+			if (tags != null) {
+				ts.addAll(tags);
+			}
 			this.tags = Collections.unmodifiableSet(ts);
 		}
 
@@ -125,49 +265,9 @@ public interface Jdk extends Comparable<Jdk> {
 		}
 
 		@Override
-		public boolean isFixedVersion() {
-			return fixedVersion;
-		}
-
-		@Override
-		@NonNull
-		public Path home() {
-			if (home == null) {
-				throw new IllegalStateException(
-						"Trying to retrieve home folder for uninstalled JDK");
-			}
-			return home;
-		}
-
-		@Override
 		@NonNull
 		public Set<String> tags() {
 			return tags;
-		}
-
-		@Override
-		public int majorVersion() {
-			return JavaUtils.parseJavaVersion(version());
-		}
-
-		@Override
-		@NonNull
-		public Jdk install() {
-			if (!provider.canUpdate()) {
-				throw new UnsupportedOperationException(
-						"Installing a JDK is not supported by " + provider);
-			}
-			return provider.install(this);
-		}
-
-		@Override
-		public void uninstall() {
-			provider.uninstall(this);
-		}
-
-		@Override
-		public boolean isInstalled() {
-			return home != null;
 		}
 
 		@Override
@@ -177,60 +277,54 @@ public interface Jdk extends Comparable<Jdk> {
 			if (o == null || getClass() != o.getClass())
 				return false;
 			Default jdk = (Default) o;
-			return id.equals(jdk.id) && Objects.equals(home, jdk.home);
+			return id.equals(jdk.id);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(home, id);
+			return Objects.hash(id);
 		}
 
 		@Override
 		public int compareTo(Jdk o) {
 			return Integer.compare(majorVersion(), o.majorVersion());
 		}
-
-		@Override
-		public String toString() {
-			return majorVersion() + " (" + version + (isFixedVersion() ? " [fixed]" : " [dynamic]") + ", " + id + ", "
-					+ home + ", " + tags + "))";
-		}
 	}
 
 	class Predicates {
-		public static final Predicate<Jdk> all = provider -> true;
+		public static final Predicate<? extends Jdk> all = provider -> true;
 
-		public static Predicate<Jdk> exactVersion(int version) {
+		public static <T extends Jdk> Predicate<T> exactVersion(int version) {
 			return jdk -> jdk.majorVersion() == version;
 		}
 
-		public static Predicate<Jdk> openVersion(int version) {
+		public static <T extends Jdk> Predicate<T> openVersion(int version) {
 			return jdk -> jdk.majorVersion() >= version;
 		}
 
-		public static Predicate<Jdk> forVersion(String version) {
+		public static <T extends Jdk> Predicate<T> forVersion(String version) {
 			int v = JavaUtils.parseJavaVersion(version);
 			return forVersion(v, JavaUtils.isOpenVersion(version));
 		}
 
-		public static Predicate<Jdk> forVersion(int version, boolean openVersion) {
+		public static <T extends Jdk> Predicate<T> forVersion(int version, boolean openVersion) {
 			return openVersion ? openVersion(version) : exactVersion(version);
 		}
 
-		public static Predicate<Jdk> fixedVersion() {
-			return Jdk::isFixedVersion;
-		}
-
-		public static Predicate<Jdk> id(String id) {
+		public static <T extends Jdk> Predicate<T> id(String id) {
 			return jdk -> jdk.id().equals(id);
 		}
 
-		public static Predicate<Jdk> path(Path jdkPath) {
-			return jdk -> jdk.isInstalled() && jdkPath.startsWith(jdk.home());
+		public static <T extends Jdk> Predicate<T> allTags(Set<String> tags) {
+			return jdk -> jdk.tags().containsAll(tags);
 		}
 
-		public static Predicate<Jdk> allTags(Set<String> tags) {
-			return jdk -> jdk.tags().containsAll(tags);
+		public static <T extends InstalledJdk> Predicate<T> fixedVersion() {
+			return InstalledJdk::isFixedVersion;
+		}
+
+		public static <T extends InstalledJdk> Predicate<T> path(Path jdkPath) {
+			return jdk -> jdkPath.startsWith(jdk.home());
 		}
 	}
 }

--- a/src/main/java/dev/jbang/devkitman/JdkInstaller.java
+++ b/src/main/java/dev/jbang/devkitman/JdkInstaller.java
@@ -23,9 +23,25 @@ public interface JdkInstaller {
 	 * @return List of <code>Jdk</code> objects
 	 */
 	@NonNull
-	default List<Jdk> listAvailable() {
+	default List<Jdk.AvailableJdk> listAvailable() {
 		throw new UnsupportedOperationException(
 				"Listing available JDKs is not supported by " + getClass().getName());
+	}
+
+	/**
+	 * Determines if a JDK matching the given version is available for installation
+	 * by this installer and if so returns its respective <code>Jdk</code> object,
+	 * otherwise it returns <code>null</code>.
+	 *
+	 * @param version     The (major) version of the JDK to return
+	 * @param openVersion Return newer version if available
+	 * @return A <code>Jdk</code> object or <code>null</code>
+	 */
+	default Jdk.@Nullable AvailableJdk getAvailableByVersion(int version, boolean openVersion) {
+		return listAvailable().stream()
+			.filter(Jdk.Predicates.forVersion(version, openVersion))
+			.findFirst()
+			.orElse(null);
 	}
 
 	/**
@@ -41,9 +57,10 @@ public interface JdkInstaller {
 	 * @param idOrToken The id or token to look for
 	 * @return A <code>Jdk</code> object or <code>null</code>
 	 */
-	@Nullable
-	default Jdk getAvailableByIdOrToken(String idOrToken) {
-		return JdkManager.getJdkBy(listAvailable().stream(), Jdk.Predicates.id(idOrToken))
+	default Jdk.@Nullable AvailableJdk getAvailableByIdOrToken(String idOrToken) {
+		return listAvailable().stream()
+			.filter(Jdk.Predicates.id(idOrToken))
+			.findFirst()
 			.orElse(null);
 	}
 
@@ -55,8 +72,7 @@ public interface JdkInstaller {
 	 * @return A <code>Jdk</code> object
 	 * @throws UnsupportedOperationException if the provider can not update
 	 */
-	@NonNull
-	default Jdk install(@NonNull Jdk jdk, Path installDir) {
+	default Jdk.@NonNull InstalledJdk install(Jdk.@NonNull AvailableJdk jdk, Path installDir) {
 		throw new UnsupportedOperationException(
 				"Installing a JDK is not supported by " + getClass().getName());
 	}
@@ -67,7 +83,7 @@ public interface JdkInstaller {
 	 * @param jdk The <code>Jdk</code> object of the JDK to uninstall
 	 * @throws UnsupportedOperationException if the provider can not update
 	 */
-	default void uninstall(@NonNull Jdk jdk) {
+	default void uninstall(Jdk.@NonNull InstalledJdk jdk) {
 		throw new UnsupportedOperationException(
 				"Uninstalling a JDK is not supported by " + getClass().getName());
 	}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/BaseFoldersJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/BaseFoldersJdkProvider.java
@@ -44,8 +44,17 @@ public abstract class BaseFoldersJdkProvider extends BaseJdkProvider {
 	}
 
 	@Override
-	public @Nullable Jdk getAvailableByIdOrToken(String idOrToken) {
-		if (isValidId(idOrToken) && super.canUpdate()) {
+	public Jdk.@Nullable AvailableJdk getAvailableByVersion(int version, boolean openVersion) {
+		if (canUpdate()) {
+			return super.getAvailableByVersion(version, openVersion);
+		} else {
+			return null;
+		}
+	}
+
+	@Override
+	public Jdk.@Nullable AvailableJdk getAvailableByIdOrToken(String idOrToken) {
+		if (isValidId(idOrToken) && canUpdate()) {
 			return super.getAvailableByIdOrToken(idOrToken);
 		} else {
 			return null;
@@ -54,7 +63,7 @@ public abstract class BaseFoldersJdkProvider extends BaseJdkProvider {
 
 	@NonNull
 	@Override
-	public List<Jdk> listInstalled() {
+	public List<Jdk.InstalledJdk> listInstalled() {
 		if (Files.isDirectory(jdksRoot)) {
 			try (Stream<Path> jdkPaths = listJdkPaths()) {
 				return jdkPaths.map(this::createJdk)
@@ -67,15 +76,13 @@ public abstract class BaseFoldersJdkProvider extends BaseJdkProvider {
 		return Collections.emptyList();
 	}
 
-	@Nullable
 	@Override
-	public Jdk getInstalledById(@NonNull String id) {
+	public Jdk.@Nullable InstalledJdk getInstalledById(@NonNull String id) {
 		return getInstalledByPath(getJdkPath(id));
 	}
 
-	@Nullable
 	@Override
-	public Jdk getInstalledByPath(@NonNull Path jdkPath) {
+	public Jdk.@Nullable InstalledJdk getInstalledByPath(@NonNull Path jdkPath) {
 		if (jdkPath.startsWith(jdksRoot) && Files.isDirectory(jdkPath) && acceptFolder(jdkPath)) {
 			return createJdk(jdkPath);
 		}
@@ -115,16 +122,14 @@ public abstract class BaseFoldersJdkProvider extends BaseJdkProvider {
 		return Stream.empty();
 	}
 
-	@Nullable
-	protected Jdk createJdk(Path home) {
+	protected Jdk.@Nullable InstalledJdk createJdk(Path home) {
 		return createJdk(home, true);
 	}
 
-	@Nullable
-	protected Jdk createJdk(Path home, boolean fixedVersion) {
+	protected Jdk.@Nullable InstalledJdk createJdk(Path home, boolean fixedVersion) {
 		String name = home.getFileName().toString();
 		if (acceptFolder(home)) {
-			return createJdk(jdkId(name), home, null, fixedVersion);
+			return createJdk(jdkId(name), home, null, fixedVersion, null);
 		}
 		return null;
 	}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/CurrentJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/CurrentJdkProvider.java
@@ -29,12 +29,12 @@ public class CurrentJdkProvider extends BaseJdkProvider {
 	}
 
 	@Override
-	public @NonNull List<Jdk> listInstalled() {
+	public @NonNull List<Jdk.InstalledJdk> listInstalled() {
 		String jh = System.getProperty("java.home");
 		if (jh != null) {
 			Path jdkHome = Paths.get(jh);
 			jdkHome = JavaUtils.jre2jdk(jdkHome);
-			Jdk jdk = createJdk(Discovery.PROVIDER_ID, jdkHome, null, false);
+			Jdk.InstalledJdk jdk = createJdk(Discovery.PROVIDER_ID, jdkHome, null, false, null);
 			if (jdk != null) {
 				return Collections.singletonList(jdk);
 			}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
@@ -1,17 +1,22 @@
 package dev.jbang.devkitman.jdkproviders;
 
+import static dev.jbang.devkitman.Jdk.InstalledJdk.Default.determineTagsFromJdkHome;
+
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import dev.jbang.devkitman.Jdk;
 import dev.jbang.devkitman.JdkDiscovery;
 import dev.jbang.devkitman.JdkProvider;
 import dev.jbang.devkitman.util.FileUtils;
+import dev.jbang.devkitman.util.JavaUtils;
 
 /**
  * This JDK provider returns the "default" JDK if it was set. This is not a JDK
@@ -38,11 +43,32 @@ public class DefaultJdkProvider extends BaseJdkProvider {
 		return "The JDK that is set as the default JDK.";
 	}
 
+	/**
+	 * This is a very special implementation that takes a path to another JDK. No
+	 * major validation is done except for the fact that the path exists and
+	 * contains a JDK. Any other validations must have been performed beforehand by
+	 * the caller.
+	 * 
+	 * @param idOrToken A string containing a path to an existing JDK
+	 * @return A jdk object or <code>null</code>
+	 */
+	@Override
+	public Jdk.@Nullable AvailableJdk getAvailableByIdOrToken(String idOrToken) {
+		Path home = Paths.get(idOrToken);
+		if (Files.isDirectory(home)) {
+			Optional<String> v = JavaUtils.resolveJavaVersionStringFromPath(home);
+			if (v.isPresent()) {
+				return new Jdk.AvailableJdk.Default(this, idOrToken, v.get(), determineTagsFromJdkHome(home));
+			}
+		}
+		return null;
+	}
+
 	@NonNull
 	@Override
-	public List<Jdk> listInstalled() {
+	public List<Jdk.InstalledJdk> listInstalled() {
 		if (Files.isDirectory(defaultJdkLink)) {
-			Jdk jdk = createJdk(Discovery.PROVIDER_ID, defaultJdkLink, null, false);
+			Jdk.InstalledJdk jdk = createJdk(Discovery.PROVIDER_ID, defaultJdkLink, null, false, null);
 			if (jdk != null) {
 				return Collections.singletonList(jdk);
 			}
@@ -51,20 +77,21 @@ public class DefaultJdkProvider extends BaseJdkProvider {
 	}
 
 	@Override
-	public @NonNull Jdk install(@NonNull Jdk jdk) {
-		Jdk defJdk = getInstalledById(Discovery.PROVIDER_ID);
-		if (defJdk != null && defJdk.isInstalled() && !jdk.equals(defJdk)) {
+	public Jdk.@NonNull InstalledJdk install(Jdk.@NonNull AvailableJdk jdk) {
+		Path home = Paths.get(jdk.id());
+		Jdk.InstalledJdk defJdk = getInstalledById(Discovery.PROVIDER_ID);
+		if (defJdk != null && defJdk.isInstalled() && !home.equals(defJdk.home())) {
 			uninstall(defJdk);
 		}
 		// Remove anything that might be in the way
 		FileUtils.deletePath(defaultJdkLink);
 		// Now create the new link
-		FileUtils.createLink(defaultJdkLink, jdk.home());
+		FileUtils.createLink(defaultJdkLink, home);
 		return defJdk;
 	}
 
 	@Override
-	public void uninstall(@NonNull Jdk jdk) {
+	public void uninstall(Jdk.@NonNull InstalledJdk jdk) {
 		FileUtils.deletePath(defaultJdkLink);
 	}
 

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/JavaHomeJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/JavaHomeJdkProvider.java
@@ -31,10 +31,10 @@ public class JavaHomeJdkProvider extends BaseJdkProvider {
 
 	@NonNull
 	@Override
-	public List<Jdk> listInstalled() {
+	public List<Jdk.InstalledJdk> listInstalled() {
 		Path jdkHome = JavaUtils.getJavaHomeEnv();
 		if (jdkHome != null && Files.isDirectory(jdkHome)) {
-			Jdk jdk = createJdk(Discovery.PROVIDER_ID, jdkHome, null, false);
+			Jdk.InstalledJdk jdk = createJdk(Discovery.PROVIDER_ID, jdkHome, null, false, null);
 			if (jdk != null) {
 				return Collections.singletonList(jdk);
 			}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/LinkedJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/LinkedJdkProvider.java
@@ -1,5 +1,7 @@
 package dev.jbang.devkitman.jdkproviders;
 
+import static dev.jbang.devkitman.Jdk.InstalledJdk.Default.determineTagsFromJdkHome;
+
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -55,7 +57,7 @@ public class LinkedJdkProvider extends BaseFoldersJdkProvider {
 					throw new IllegalArgumentException(
 							"Unable to determine Java version in given path: " + jdkPath);
 				}
-				return new Jdk.AvailableJdk.Default(this, idOrToken, version.get(), null);
+				return new Jdk.AvailableJdk.Default(this, idOrToken, version.get(), determineTagsFromJdkHome(jdkPath));
 			}
 			return null;
 		} else {

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/MultiHomeJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/MultiHomeJdkProvider.java
@@ -33,14 +33,14 @@ public class MultiHomeJdkProvider extends BaseJdkProvider {
 
 	@NonNull
 	@Override
-	public List<Jdk> listInstalled() {
+	public List<Jdk.InstalledJdk> listInstalled() {
 		return System.getenv()
 			.entrySet()
 			.stream()
 			.filter(entry -> entry.getKey().startsWith("JAVA_HOME_"))
 			.map(entry -> Paths.get(entry.getValue()))
 			.filter(Files::isDirectory)
-			.map(jdkHome -> createJdk(Discovery.PROVIDER_ID, jdkHome, null, false))
+			.map(jdkHome -> createJdk(Discovery.PROVIDER_ID, jdkHome, null, false, null))
 			.filter(Objects::nonNull)
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/PathJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/PathJdkProvider.java
@@ -30,7 +30,7 @@ public class PathJdkProvider extends BaseJdkProvider {
 
 	@NonNull
 	@Override
-	public List<Jdk> listInstalled() {
+	public List<Jdk.InstalledJdk> listInstalled() {
 		Path jdkHome = null;
 		Path javac = OsUtils.searchPath("javac");
 		if (javac != null) {
@@ -38,7 +38,7 @@ public class PathJdkProvider extends BaseJdkProvider {
 			jdkHome = javac.getParent().getParent();
 		}
 		if (jdkHome != null) {
-			Jdk jdk = createJdk(Discovery.PROVIDER_ID, jdkHome, null, false);
+			Jdk.InstalledJdk jdk = createJdk(Discovery.PROVIDER_ID, jdkHome, null, false, null);
 			if (jdk != null) {
 				return Collections.singletonList(jdk);
 			}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/ScoopJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/ScoopJdkProvider.java
@@ -40,9 +40,8 @@ public class ScoopJdkProvider extends BaseFoldersJdkProvider {
 		return jdkFolder.getFileName().startsWith("openjdk") && super.acceptFolder(jdkFolder);
 	}
 
-	@Nullable
 	@Override
-	protected Jdk createJdk(Path home) {
+	protected Jdk.@Nullable InstalledJdk createJdk(Path home) {
 		try {
 			// Try to resolve any links
 			home = home.toRealPath();

--- a/src/test/java/dev/jbang/devkitman/BaseTest.java
+++ b/src/test/java/dev/jbang/devkitman/BaseTest.java
@@ -176,7 +176,7 @@ public class BaseTest {
 		RemoteAccessProvider rap = new RemoteAccessProvider() {
 			@Override
 			public Path downloadFromUrl(String url) throws IOException {
-				if (!url.startsWith("https://api.foojay.io/disco/v3.0/directuris?")) {
+				if (!url.startsWith("https://api.foojay.io/disco/v3.0/ids/") || !url.endsWith("/redirect")) {
 					throw new IOException("Unexpected URL: " + url);
 				}
 				return testJdkFile;
@@ -195,7 +195,7 @@ public class BaseTest {
 		};
 
 		JBangJdkProvider jbang = new JBangJdkProvider(config.installPath);
-		FoojayJdkInstaller installer = new FoojayJdkInstaller(jbang);
+		FoojayJdkInstaller installer = new FoojayJdkInstaller(jbang, jbang::jdkId);
 		installer.remoteAccessProvider(rap);
 		jbang.installer(installer);
 		return jbang;

--- a/src/test/java/dev/jbang/devkitman/TestJdkInstaller.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkInstaller.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,10 +14,27 @@ import dev.jbang.devkitman.jdkproviders.JBangJdkProvider;
 public class TestJdkInstaller extends BaseTest {
 
 	@Test
-	void testInstall() throws IOException {
+	void testListAvailable() throws IOException {
 		JdkManager jm = jdkManager("jbang");
-		Jdk jdk = jm.getOrInstallJdk("12");
+		List<Jdk.AvailableJdk> jdks = jm.listAvailableJdks();
+		assertThat(jdks, hasSize(18));
+		assertThat(jdks.get(0).majorVersion(), is(25));
+		assertThat(jdks.get(jdks.size() - 1).majorVersion(), is(8));
+	}
+
+	@Test
+	void testInstallExact() throws IOException {
+		JdkManager jm = jdkManager("jbang");
+		Jdk.InstalledJdk jdk = jm.getOrInstallJdk("12");
 		assertThat(jdk.provider(), instanceOf(JBangJdkProvider.class));
 		assertThat(jdk.home().toString(), endsWith(File.separator + "12"));
+	}
+
+	@Test
+	void testInstallOpen() throws IOException {
+		JdkManager jm = jdkManager("jbang");
+		Jdk.InstalledJdk jdk = jm.getOrInstallJdk("12+");
+		assertThat(jdk.provider(), instanceOf(JBangJdkProvider.class));
+		assertThat(jdk.home().toString(), endsWith(File.separator + "21"));
 	}
 }

--- a/src/test/java/dev/jbang/devkitman/TestJdkManager.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkManager.java
@@ -118,7 +118,7 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getInstalledJdk(null), not(nullValue()));
 		Set<String> tags = jm.getInstalledJdk(null).tags();
-		assertThat(tags, contains("Jdk"));
+		assertThat(tags, containsInAnyOrder("Jdk", "Ga"));
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getInstalledJdk(null), not(nullValue()));
 		Set<String> tags = jm.getInstalledJdk(null).tags();
-		assertThat(tags, containsInAnyOrder("Jdk", "Graalvm"));
+		assertThat(tags, containsInAnyOrder("Jdk", "Ga", "Graalvm"));
 	}
 
 	@Test
@@ -146,7 +146,7 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getInstalledJdk(null), not(nullValue()));
 		Set<String> tags = jm.getInstalledJdk(null).tags();
-		assertThat(tags, containsInAnyOrder("Jdk", "Graalvm", "Native"));
+		assertThat(tags, containsInAnyOrder("Jdk", "Ga", "Graalvm", "Native"));
 	}
 
 	@Test
@@ -155,7 +155,7 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getInstalledJdk(null), not(nullValue()));
 		Set<String> tags = jm.getInstalledJdk(null).tags();
-		assertThat(tags, containsInAnyOrder("Jdk", "Javafx"));
+		assertThat(tags, containsInAnyOrder("Jdk", "Ga", "Javafx"));
 	}
 
 	@Test

--- a/src/test/java/dev/jbang/devkitman/TestJdkManager.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkManager.java
@@ -30,7 +30,7 @@ public class TestJdkManager extends BaseTest {
 	@Test
 	void testHasJdksInstalled() {
 		Arrays.asList(11, 12, 13).forEach(this::createMockJdk);
-		List<Jdk> jdks = jdkManager().listInstalledJdks();
+		List<Jdk.InstalledJdk> jdks = jdkManager().listInstalledJdks();
 		assertThat(jdks, hasSize(4));
 		assertThat(
 				jdks.stream().map(Jdk::majorVersion).collect(Collectors.toList()),
@@ -47,7 +47,7 @@ public class TestJdkManager extends BaseTest {
 		Path jdkPath = createMockJdkExt(13);
 		environmentVariables.set("JAVA_HOME", jdkPath.toString());
 
-		List<Jdk> jdks = jdkManager("default", "javahome", "jbang").listInstalledJdks();
+		List<Jdk.InstalledJdk> jdks = jdkManager("default", "javahome", "jbang").listInstalledJdks();
 		assertThat(jdks, hasSize(4));
 		assertThat(
 				jdks.stream().map(Jdk::majorVersion).collect(Collectors.toList()),
@@ -56,14 +56,14 @@ public class TestJdkManager extends BaseTest {
 				jdks.stream().map(Jdk::version).collect(Collectors.toList()),
 				containsInAnyOrder("11.0.7", "11.0.7", "12.0.7", "13.0.7"));
 		assertThat(
-				jdks.stream().map(Jdk::isFixedVersion).collect(Collectors.toList()),
+				jdks.stream().map(Jdk.InstalledJdk::isFixedVersion).collect(Collectors.toList()),
 				containsInAnyOrder(false, true, true, false));
 	}
 
 	@Test
 	void testHasJdksInstalledAllProvider() {
 		Arrays.asList(11, 12, 13).forEach(this::createMockJdk);
-		List<Jdk> jdks = jdkManager(JdkProviders.instance().allNames().toArray(new String[] {}))
+		List<Jdk.InstalledJdk> jdks = jdkManager(JdkProviders.instance().allNames().toArray(new String[] {}))
 			.listInstalledJdks();
 		assertThat(jdks, hasSize(greaterThanOrEqualTo(5)));
 	}
@@ -202,7 +202,7 @@ public class TestJdkManager extends BaseTest {
 		environmentVariables.set("JAVA_HOME", jdkPath.toString());
 
 		JdkManager jm = jdkManager("javahome", "jbang");
-		Jdk jdk = jm.getInstalledJdk("12");
+		Jdk.InstalledJdk jdk = jm.getInstalledJdk("12");
 		assertThat(jdk.provider(), instanceOf(JavaHomeJdkProvider.class));
 		assertThat(jdk.home().toString(), endsWith(File.separator + "jdk12"));
 	}
@@ -216,7 +216,7 @@ public class TestJdkManager extends BaseTest {
 
 		JdkManager jm = jdkManager("default", "javahome", "jbang");
 		jm.setDefaultJdk(jm.getInstalledJdk("12"));
-		Jdk jdk = jm.getInstalledJdk("12");
+		Jdk.InstalledJdk jdk = jm.getInstalledJdk("12");
 		assertThat(jdk.provider(), instanceOf(DefaultJdkProvider.class));
 		assertThat(jdk.home().toString(), endsWith(File.separator + "default"));
 		assertThat(jdk.home().toRealPath().toString(), endsWith(File.separator + "jdk12"));
@@ -231,7 +231,7 @@ public class TestJdkManager extends BaseTest {
 				"PATH", jdkPath.resolve("bin") + File.pathSeparator + System.getenv("PATH"));
 
 		JdkManager jm = jdkManager("path", "jbang");
-		Jdk jdk = jm.getInstalledJdk("12");
+		Jdk.InstalledJdk jdk = jm.getInstalledJdk("12");
 		assertThat(jdk.provider(), instanceOf(PathJdkProvider.class));
 		assertThat(jdk.home().toString(), endsWith(File.separator + "jdk12"));
 	}
@@ -240,7 +240,7 @@ public class TestJdkManager extends BaseTest {
 	void testLinkToExistingJdkPath() {
 		Path jdkPath = createMockJdkExt(12);
 		jdkManager().linkToExistingJdk(jdkPath, "12");
-		List<Jdk> jdks = jdkManager().listInstalledJdks();
+		List<Jdk.InstalledJdk> jdks = jdkManager().listInstalledJdks();
 		assertThat(jdks, hasSize(1));
 		assertThat(jdks.get(0).provider(), instanceOf(LinkedJdkProvider.class));
 	}
@@ -346,13 +346,13 @@ public class TestJdkManager extends BaseTest {
 		environmentVariables.set("JAVA_HOME_17_X64", jdkPath2.toString());
 
 		JdkManager jm = jdkManager("multihome");
-		Jdk jdk = jm.getInstalledJdk("12");
+		Jdk.InstalledJdk jdk = jm.getInstalledJdk("12");
 		assertThat(jdk.provider(), instanceOf(MultiHomeJdkProvider.class));
 		assertThat(jdk.home().toString(), endsWith(File.separator + "jdk12"));
 		jdk = jm.getInstalledJdk("17");
 		assertThat(jdk.provider(), instanceOf(MultiHomeJdkProvider.class));
 		assertThat(jdk.home().toString(), endsWith(File.separator + "jdk17"));
-		List<Jdk> jdks = jm.listInstalledJdks();
+		List<Jdk.InstalledJdk> jdks = jm.listInstalledJdks();
 		assertThat(jdks, hasSize(2));
 		assertThat(jdks.stream().map(Jdk::majorVersion).collect(Collectors.toList()), containsInAnyOrder(12, 17));
 	}

--- a/src/test/java/dev/jbang/devkitman/jdkproviders/JdkProviderWrapper.java
+++ b/src/test/java/dev/jbang/devkitman/jdkproviders/JdkProviderWrapper.java
@@ -37,37 +37,37 @@ public class JdkProviderWrapper implements JdkProvider {
 	}
 
 	@Override
-	public @NonNull List<Jdk> listInstalled() {
+	public @NonNull List<Jdk.InstalledJdk> listInstalled() {
 		return provider.listInstalled();
 	}
 
 	@Override
-	public Jdk getInstalledById(@NonNull String id) {
+	public Jdk.InstalledJdk getInstalledById(@NonNull String id) {
 		return provider.getInstalledById(id);
 	}
 
 	@Override
-	public Jdk getInstalledByPath(@NonNull Path jdkPath) {
+	public Jdk.InstalledJdk getInstalledByPath(@NonNull Path jdkPath) {
 		return provider.getInstalledByPath(jdkPath);
 	}
 
 	@Override
-	public @NonNull List<Jdk> listAvailable() {
+	public @NonNull List<Jdk.AvailableJdk> listAvailable() {
 		return provider.listAvailable();
 	}
 
 	@Override
-	public Jdk getAvailableByIdOrToken(String idOrToken) {
+	public Jdk.AvailableJdk getAvailableByIdOrToken(String idOrToken) {
 		return provider.getAvailableByIdOrToken(idOrToken);
 	}
 
 	@Override
-	public @NonNull Jdk install(@NonNull Jdk jdk) {
+	public Jdk.@NonNull InstalledJdk install(Jdk.@NonNull AvailableJdk jdk) {
 		return provider.install(jdk);
 	}
 
 	@Override
-	public void uninstall(@NonNull Jdk jdk) {
+	public void uninstall(Jdk.@NonNull InstalledJdk jdk) {
 		provider.uninstall(jdk);
 	}
 }

--- a/src/test/java/dev/jbang/devkitman/jdkproviders/MockJdkProvider.java
+++ b/src/test/java/dev/jbang/devkitman/jdkproviders/MockJdkProvider.java
@@ -3,6 +3,7 @@ package dev.jbang.devkitman.jdkproviders;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,20 +28,20 @@ public class MockJdkProvider extends BaseFoldersJdkProvider {
 	}
 
 	@Override
-	public @NonNull List<Jdk> listAvailable() {
+	public @NonNull List<Jdk.AvailableJdk> listAvailable() {
 		return Arrays.stream(versions)
-			.mapToObj(v -> createJdk(v + "-dummy", null, v + ".0.7", true))
+			.mapToObj(v -> new Jdk.AvailableJdk.Default(this, v + "-dummy", v + ".0.7", null))
 			.collect(Collectors.toList());
 	}
 
 	@Override
-	public @NonNull Jdk install(@NonNull Jdk jdk) {
+	public Jdk.@NonNull InstalledJdk install(Jdk.@NonNull AvailableJdk jdk) {
 		Path jdkPath = mockJdk.apply(jdk.majorVersion());
-		return createJdk(jdk.id(), jdkPath, jdk.version(), true);
+		return Objects.requireNonNull(createJdk(jdk.id(), jdkPath, jdk.version(), true, null));
 	}
 
 	@Override
-	public void uninstall(@NonNull Jdk jdk) {
+	public void uninstall(Jdk.@NonNull InstalledJdk jdk) {
 		if (jdk.isInstalled()) {
 			FileUtils.deletePath(jdk.home());
 		}


### PR DESCRIPTION
This started with wanting to avoid the use of the /redirecturl endpoint which doesn't 100% work the same as the /packages endpoint which was causing issues.

To do that without generating extra requests it had to be possible to store the download url in the Jdk objects returned from FoojayJdkInstaller, which meant being able to add extra information to the object. In the end I decided to do that with subclassing, but that meant having to refactor the way Jdk objects are created. The Jdk objects also represented two different uses of the Jdk in the code: one for Jdks that are available for installation and another that represents an installed Jdk. This is now exposed in the object model as two different classes: AvailableJdk and InstalledJdk, each with operations that are only valid for that particular class.

Additionally the FoojayJdkInstaller now adds tags to each available Jdk.

And finally the FoojayJdkInstaller was made faster in some circumstances because it turns out that asking for both GA and EA releases in a single request is really slow (really because requesting EA releases is slow). So now, when trying to get a single version, we first ask for GA releases and only when that doesn't give us any results we'll do a second request for EA releases.