### PR TITLE
fix: don't create temp folders all the time

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -4,6 +4,10 @@ current_version := "0.2.0"
 default:
     @ just -l
 
+# clean build artifacts
+clean:
+    ./gradlew clean
+
 # build without tests
 build:
     ./gradlew spotlessApply build -x test

--- a/src/main/java/dev/jbang/devkitman/JdkDiscovery.java
+++ b/src/main/java/dev/jbang/devkitman/JdkDiscovery.java
@@ -26,11 +26,10 @@ public interface JdkDiscovery {
 
 	class Config {
 		@NonNull
-		public final Path installPath;
+		private final Path installPath;
+		private Path cachePath;
 		@NonNull
-		public final Path cachePath;
-		@NonNull
-		public final Map<String, String> properties;
+		private final Map<String, String> properties;
 
 		public Config(@NonNull Path installPaths) {
 			this(installPaths, null, null);
@@ -41,19 +40,32 @@ public interface JdkDiscovery {
 				@Nullable Path cachePath,
 				@Nullable Map<String, String> properties) {
 			this.installPath = installPath;
-			if (cachePath == null) {
-				try {
-					this.cachePath = deleteOnExit(Files.createTempDirectory("jdk-provider-cache"));
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			} else {
-				this.cachePath = cachePath;
-			}
+			this.cachePath = cachePath;
 			this.properties = new HashMap<>();
 			if (properties != null) {
 				this.properties.putAll(properties);
 			}
+		}
+
+		public @NonNull Path installPath() {
+			return installPath;
+		}
+
+		public @NonNull Path cachePath() {
+			if (cachePath == null) {
+				// If no cache path is set, we create a temp dir as a curtesy that will be
+				// deleted on exit
+				try {
+					cachePath = deleteOnExit(Files.createTempDirectory("jdk-provider-cache"));
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			return cachePath;
+		}
+
+		public @NonNull Map<String, String> properties() {
+			return properties;
 		}
 
 		public Config copy() {

--- a/src/main/java/dev/jbang/devkitman/JdkManager.java
+++ b/src/main/java/dev/jbang/devkitman/JdkManager.java
@@ -37,7 +37,7 @@ public class JdkManager {
 	public static JdkManager create() {
 		Path installPath = JBangJdkProvider.getJBangJdkDir();
 		JdkDiscovery.Config cfg = new JdkDiscovery.Config(installPath);
-		cfg.properties.put("link", JBangJdkProvider.getJBangConfigDir().resolve("currentjdk").toString());
+		cfg.properties().put("link", JBangJdkProvider.getJBangConfigDir().resolve("currentjdk").toString());
 		return builder().providers(JdkProviders.instance().all(cfg)).build();
 	}
 

--- a/src/main/java/dev/jbang/devkitman/JdkProviders.java
+++ b/src/main/java/dev/jbang/devkitman/JdkProviders.java
@@ -100,7 +100,7 @@ public class JdkProviders {
 		for (int i = 1; i < parts.length; i++) {
 			String[] keyValue = parts[i].split("=");
 			if (keyValue.length == 2) {
-				providerConfig.properties.put(keyValue[0], keyValue[1]);
+				providerConfig.properties().put(keyValue[0], keyValue[1]);
 			}
 		}
 		return action.apply(name, providerConfig);

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
@@ -106,8 +106,9 @@ public class DefaultJdkProvider extends BaseJdkProvider {
 
 		@Override
 		public JdkProvider create(Config config) {
-			String defaultLink = config.properties.computeIfAbsent("link",
-					k -> config.installPath.resolve(PROVIDER_ID).toString());
+			String defaultLink = config.properties()
+				.computeIfAbsent("link",
+						k -> config.installPath().resolve(PROVIDER_ID).toString());
 			return new DefaultJdkProvider(Paths.get(defaultLink));
 		}
 	}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/JBangJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/JBangJdkProvider.java
@@ -169,10 +169,10 @@ public class JBangJdkProvider extends BaseFoldersJdkProvider {
 
 		@Override
 		public JdkProvider create(Config config) {
-			JBangJdkProvider prov = new JBangJdkProvider(config.installPath);
+			JBangJdkProvider prov = new JBangJdkProvider(config.installPath());
 			return prov
 				.installer(new FoojayJdkInstaller(prov, prov::jdkId)
-					.distro(config.properties.getOrDefault("distro", null)));
+					.distro(config.properties().getOrDefault("distro", null)));
 			// TODO make RAP configurable
 			// .remoteAccessProvider(RemoteAccessProvider.createDefaultRemoteAccessProvider(config.cachePath));
 		}

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/LinkedJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/LinkedJdkProvider.java
@@ -146,7 +146,7 @@ public class LinkedJdkProvider extends BaseFoldersJdkProvider {
 
 		@Override
 		public JdkProvider create(Config config) {
-			return new LinkedJdkProvider(config.installPath);
+			return new LinkedJdkProvider(config.installPath());
 		}
 	}
 }

--- a/src/test/java/dev/jbang/devkitman/BaseTest.java
+++ b/src/test/java/dev/jbang/devkitman/BaseTest.java
@@ -93,7 +93,7 @@ public class BaseTest {
 
 	protected JdkManager mockJdkManager(Function<Integer, Path> mockJdk, int... versions) {
 		return JdkManager.builder()
-			.providers(new MockJdkProvider(config.installPath, mockJdk, versions))
+			.providers(new MockJdkProvider(config.installPath(), mockJdk, versions))
 			.build();
 	}
 
@@ -106,9 +106,9 @@ public class BaseTest {
 	}
 
 	protected Path createMockJdk(int jdkVersion, BiConsumer<Path, String> init) {
-		Path jdkPath = config.installPath.resolve(String.valueOf(jdkVersion));
+		Path jdkPath = config.installPath().resolve(String.valueOf(jdkVersion));
 		init.accept(jdkPath, jdkVersion + ".0.7");
-		Path link = config.installPath.resolve("default");
+		Path link = config.installPath().resolve("default");
 		if (!Files.exists(link)) {
 			FileUtils.createLink(link, jdkPath);
 		}
@@ -116,7 +116,7 @@ public class BaseTest {
 	}
 
 	protected Path createMockJdkExt(int jdkVersion) {
-		Path jdkPath = config.cachePath.resolve("jdk" + jdkVersion);
+		Path jdkPath = config.cachePath().resolve("jdk" + jdkVersion);
 		FileUtils.mkdirs(jdkPath);
 		initMockJdkDir(jdkPath, jdkVersion + ".0.7");
 		return jdkPath;
@@ -194,7 +194,7 @@ public class BaseTest {
 			}
 		};
 
-		JBangJdkProvider jbang = new JBangJdkProvider(config.installPath);
+		JBangJdkProvider jbang = new JBangJdkProvider(config.installPath());
 		FoojayJdkInstaller installer = new FoojayJdkInstaller(jbang, jbang::jdkId);
 		installer.remoteAccessProvider(rap);
 		jbang.installer(installer);

--- a/src/test/java/dev/jbang/devkitman/TestJdkProviders.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkProviders.java
@@ -109,10 +109,9 @@ public class TestJdkProviders extends BaseTest {
 							name,
 							(prov, config) -> {
 								assertThat(prov, equalTo("jbang"));
-								assertThat(config.properties, hasEntry("aap", "noot"));
-								assertThat(config.properties, hasEntry("mies", "wim"));
-								return new JBangJdkProvider(
-										config.installPath);
+								assertThat(config.properties(), hasEntry("aap", "noot"));
+								assertThat(config.properties(), hasEntry("mies", "wim"));
+								return new JBangJdkProvider(config.installPath());
 							}),
 				is(instanceOf(JBangJdkProvider.class)));
 	}


### PR DESCRIPTION
The `Config` class would create temporary folders every time it was instantiated. This is now done only on demand.