### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -41,9 +41,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./gradlew --no-daemon --build-cache --scan -s clean publish jreleaserRelease
       - name: release-output
         if: always()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: upload-release-output
           path: |


### PR DESCRIPTION
Pin all action references to full-length commit SHAs for supply chain security.

This is required for enabling the org-level policy:
**Require actions to be pinned to a full-length commit SHA**

Original version tags are preserved as comments for readability.
Consider adding Dependabot for GitHub Actions to keep pins updated:

```yaml
# .github/dependabot.yml
version: 2
updates:
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pin GitHub Action versions (checkout and Java setup) for more stable builds.
  * Pinned artifact upload action in the release workflow to ensure consistent release output handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jbangdev/jbang-devkitman/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->