### PR TITLE
Fix: now properly removing dangling default links

### DIFF
--- a/src/main/java/dev/jbang/devkitman/JdkManager.java
+++ b/src/main/java/dev/jbang/devkitman/JdkManager.java
@@ -478,7 +478,7 @@ public class JdkManager implements JdkDistroQuery {
 					resetDefault = defHome.equals(jdk.home());
 				}
 			}
-			// Check if the JDK is the global default JDK, if so we need to reset it
+			// Check if the JDK is the version default JDK, if so we need to reset it
 			Jdk.InstalledJdk defaultJdkVer = getDefaultJdk();
 			if (defaultJdkVer != null) {
 				Path defHome = defaultJdkVer.home();

--- a/src/main/java/dev/jbang/devkitman/JdkManager.java
+++ b/src/main/java/dev/jbang/devkitman/JdkManager.java
@@ -464,36 +464,44 @@ public class JdkManager implements JdkDistroQuery {
 	}
 
 	void uninstallJdk(Jdk.@NonNull InstalledJdk jdk) {
-		boolean resetDefault = false;
-		boolean resetDefaultVer = false;
+		Jdk.InstalledJdk resetDefault = null;
+		Jdk.InstalledJdk resetDefaultVer = null;
 		if (hasDefaultProvider() && !jdk.provider().equals(defaultProvider)) {
 			// Check if the JDK is the global default JDK, if so we need to reset it
 			Jdk.InstalledJdk defaultJdk = getDefaultJdk();
 			if (defaultJdk != null) {
+				boolean reset;
 				Path defHome = defaultJdk.home();
 				try {
-					resetDefault = Files.isSameFile(defHome, jdk.home());
+					reset = Files.isSameFile(defHome, jdk.home());
 				} catch (IOException ex) {
 					LOGGER.log(Level.WARNING, "Error while trying to reset global default JDK", ex);
-					resetDefault = defHome.equals(jdk.home());
+					reset = defHome.equals(jdk.home());
+				}
+				if (reset) {
+					resetDefault = defaultJdk;
 				}
 			}
 			// Check if the JDK is the version default JDK, if so we need to reset it
-			Jdk.InstalledJdk defaultJdkVer = getDefaultJdk();
+			Jdk.InstalledJdk defaultJdkVer = getDefaultJdkForVersion(jdk.majorVersion());
 			if (defaultJdkVer != null) {
+				boolean reset;
 				Path defHome = defaultJdkVer.home();
 				try {
-					resetDefaultVer = Files.isSameFile(defHome, jdk.home());
+					reset = Files.isSameFile(defHome, jdk.home());
 				} catch (IOException ex) {
 					LOGGER.log(Level.WARNING, "Error while trying to reset versioned default JDK", ex);
-					resetDefaultVer = defHome.equals(jdk.home());
+					reset = defHome.equals(jdk.home());
+				}
+				if (reset) {
+					resetDefaultVer = defaultJdkVer;
 				}
 			}
 		}
 
 		jdk.provider().uninstall(jdk);
 
-		if (resetDefault) {
+		if (resetDefault != null) {
 			Optional<Jdk.InstalledJdk> newjdk = nextInstalledJdk(Jdk.Predicates.minVersion(jdk.majorVersion()),
 					JdkProvider.Predicates.canInstall);
 			if (!newjdk.isPresent()) {
@@ -503,11 +511,11 @@ public class JdkManager implements JdkDistroQuery {
 			if (newjdk.isPresent()) {
 				setDefaultJdk(newjdk.get());
 			} else {
-				removeDefaultJdk();
+				resetDefault.uninstall();
 				LOGGER.log(Level.INFO, "Global default JDK unset");
 			}
 		}
-		if (resetDefaultVer) {
+		if (resetDefaultVer != null) {
 			int v = jdk.majorVersion();
 			Optional<Jdk.InstalledJdk> newjdk = nextInstalledJdk(Jdk.Predicates.exactVersion(v),
 					JdkProvider.Predicates.canInstall);
@@ -517,7 +525,7 @@ public class JdkManager implements JdkDistroQuery {
 			if (newjdk.isPresent()) {
 				setDefaultJdkForVersion(newjdk.get());
 			} else {
-				removeDefaultJdkForVersion(v);
+				resetDefaultVer.uninstall();
 				LOGGER.log(Level.INFO, "Versioned default JDK unset");
 			}
 		}

--- a/src/main/java/dev/jbang/devkitman/util/FileUtils.java
+++ b/src/main/java/dev/jbang/devkitman/util/FileUtils.java
@@ -15,10 +15,12 @@ public class FileUtils {
 			// creation doesn't require any special privileges.
 			if (OsUtils.isWindows() && Files.isDirectory(target)) {
 				if (createJunction(link, target.toAbsolutePath())) {
+					LOGGER.log(Level.FINE, "Created link (junction) {0}", target);
 					return;
 				}
 			} else {
 				if (createSymbolicLink(link, target.toAbsolutePath())) {
+					LOGGER.log(Level.FINE, "Created link (symbolic) {0}", target);
 					return;
 				}
 			}

--- a/src/test/java/dev/jbang/devkitman/TestJdkManager.java
+++ b/src/test/java/dev/jbang/devkitman/TestJdkManager.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -83,6 +85,12 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getDefaultJdk(), not(nullValue()));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(11));
+		assertThat(jm.getDefaultJdkForVersion(11), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(11).majorVersion(), is(11));
+		assertThat(jm.getDefaultJdkForVersion(12), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(12).majorVersion(), is(12));
+		assertThat(jm.getDefaultJdkForVersion(13), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(13).majorVersion(), is(13));
 		jm.setDefaultJdk(Objects.requireNonNull(jm.getInstalledJdk("12")));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(12));
 		assertThat(jm.getDefaultJdk().linked().id(), startsWith("12.0.7-distro-jbang"));
@@ -94,6 +102,12 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getDefaultJdk(), not(nullValue()));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(11));
+		assertThat(jm.getDefaultJdkForVersion(11), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(11).majorVersion(), is(11));
+		assertThat(jm.getDefaultJdkForVersion(14), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(14).majorVersion(), is(14));
+		assertThat(jm.getDefaultJdkForVersion(17), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(17).majorVersion(), is(17));
 		jm.setDefaultJdk(Objects.requireNonNull(jm.getInstalledJdk("16+")));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(17));
 	}
@@ -194,9 +208,18 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getDefaultJdk(), not(nullValue()));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(14));
+		assertThat(jm.getDefaultJdkForVersion(11), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(11).majorVersion(), is(11));
+		assertThat(jm.getDefaultJdkForVersion(14), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(14).majorVersion(), is(14));
+		assertThat(jm.getDefaultJdkForVersion(17), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(17).majorVersion(), is(17));
+		Jdk.LinkedJdk jdk14 = jm.getDefaultJdkForVersion(14);
 		jm.getInstalledJdk("14", JdkProvider.Predicates.canInstall).uninstall();
 		assertThat(jm.getDefaultJdk(), not(nullValue()));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(17));
+		assertThat(jm.getDefaultJdkForVersion(14), nullValue());
+		assertThat(Files.exists(jdk14.home(), LinkOption.NOFOLLOW_LINKS), is(false));
 	}
 
 	@Test
@@ -205,9 +228,17 @@ public class TestJdkManager extends BaseTest {
 		JdkManager jm = jdkManager();
 		assertThat(jm.getDefaultJdk(), not(nullValue()));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(17));
+		assertThat(jm.getDefaultJdkForVersion(11), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(11).majorVersion(), is(11));
+		assertThat(jm.getDefaultJdkForVersion(14), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(14).majorVersion(), is(14));
+		assertThat(jm.getDefaultJdkForVersion(17), not(nullValue()));
+		assertThat(jm.getDefaultJdkForVersion(17).majorVersion(), is(17));
+		Jdk.LinkedJdk jdk17 = jm.getDefaultJdkForVersion(17);
 		jm.getInstalledJdk("17", JdkProvider.Predicates.canInstall).uninstall();
 		assertThat(jm.getDefaultJdk(), not(nullValue()));
 		assertThat(jm.getDefaultJdk().majorVersion(), is(14));
+		assertThat(Files.exists(jdk17.home(), LinkOption.NOFOLLOW_LINKS), is(false));
 	}
 
 	@Test
@@ -455,7 +486,9 @@ public class TestJdkManager extends BaseTest {
 		assertThat(jdks.stream().map(Jdk::majorVersion).collect(Collectors.toList()), containsInAnyOrder(11, 11, 11));
 		assertThat(jdks.stream().map(Jdk::id).collect(Collectors.toList()),
 				containsInAnyOrder("default", "12-default", "11-jbang"));
-		jdkManager().getOrInstallJdk("12", JdkProvider.Predicates.canUpdate).uninstall();
+		Jdk.InstalledJdk jdk12 = jdkManager().getOrInstallJdk("12", JdkProvider.Predicates.canUpdate);
+		jdk12.uninstall();
+		assertThat(Files.exists(jdk12.home(), LinkOption.NOFOLLOW_LINKS), is(false));
 		jdks = jdkManager().listInstalledJdks();
 		assertThat(jdks, hasSize(2));
 		assertThat(jdks.stream().map(Jdk::majorVersion).collect(Collectors.toList()), containsInAnyOrder(11, 11));
@@ -484,6 +517,9 @@ public class TestJdkManager extends BaseTest {
 		assertThat(jdks.stream().map(Jdk::id).collect(Collectors.toList()),
 				containsInAnyOrder("default", "13-default", "13.0.7-distro-jbang"));
 		jm.getOrInstallJdk("13", JdkProvider.Predicates.canInstall).uninstall();
+		for (Jdk.InstalledJdk jdk : jdks) {
+			assertThat(Files.exists(jdk.home(), LinkOption.NOFOLLOW_LINKS), is(false));
+		}
 		jdks = jm.listInstalledJdks();
 		assertThat(jdks, empty());
 	}


### PR DESCRIPTION
The links for global default and version default JDKs weren't properly removed, confusing older JBang versions.

