### PR TITLE
fix: resolve path canonicalization issue in acceptFolder on macOS/Windows

### DIFF
--- a/src/main/java/dev/jbang/devkitman/jdkproviders/BaseFoldersJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/BaseFoldersJdkProvider.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -130,7 +131,35 @@ public abstract class BaseFoldersJdkProvider extends BaseJdkProvider {
 	}
 
 	protected boolean acceptFolder(@NonNull Path jdkFolder) {
-		return jdkFolder.startsWith(jdksRoot) && JavaUtils.hasJavacCmd(jdkFolder);
+		return isUnderRoot(jdkFolder) && JavaUtils.hasJavacCmd(jdkFolder);
+	}
+
+	/**
+	 * Checks if the given path is under the jdksRoot directory. This method handles
+	 * the case where the paths may have different canonical forms (e.g. /var vs
+	 * /private/var on macOS) by falling back to toRealPath() comparison when a
+	 * simple startsWith check fails.
+	 */
+	protected boolean isUnderRoot(@NonNull Path jdkFolder) {
+		if (jdkFolder.startsWith(jdksRoot)) {
+			return true;
+		}
+		try {
+			return jdkFolder.toRealPath().startsWith(realJdksRoot());
+		} catch (IOException e) {
+			return false;
+		}
+	}
+
+	private final AtomicReference<Path> realJdksRootCache = new AtomicReference<>();
+
+	private Path realJdksRoot() throws IOException {
+		Path cached = realJdksRootCache.get();
+		if (cached == null) {
+			cached = jdksRoot.toRealPath();
+			realJdksRootCache.set(cached);
+		}
+		return cached;
 	}
 
 	private final Pattern validId = Pattern.compile("^[a-zA-Z0-9._+-]+$");

--- a/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
+++ b/src/main/java/dev/jbang/devkitman/jdkproviders/DefaultJdkProvider.java
@@ -158,7 +158,7 @@ public class DefaultJdkProvider extends BaseFoldersJdkProvider {
 	}
 
 	protected boolean acceptFolder(@NonNull Path jdkFolder) {
-		if (!jdkFolder.equals(defaultJdkLink) && !jdkFolder.startsWith(jdksRoot)) {
+		if (!jdkFolder.equals(defaultJdkLink) && !isUnderRoot(jdkFolder)) {
 			return false;
 		}
 		String nm = jdkFolder.getFileName().toString();


### PR DESCRIPTION
On macOS, temp directories resolve through `/private/var` (e.g. `/var/folders/...` → `/private/var/folders/...`) causing `jdkFolder.startsWith(jdksRoot)` to return `false` when the `jdkFolder` path has been resolved via `toRealPath()` but `jdksRoot` has not.

This caused `LinkedJdk.linked()` to fall through to `ExternalJdkProvider`, producing `external-<hash>` ids instead of the correct provider id (e.g. `17.0.7-jbang`).

### Fix

Adds an `isUnderRoot()` helper in `BaseFoldersJdkProvider` that falls back to comparing real (canonical) paths when the simple `startsWith` check fails. The resolved real root path is cached for performance. `DefaultJdkProvider.acceptFolder()` is updated to use the same helper.

### Related

- #106 — CI: cross-platform test matrix that exposes this failure
- jbangdev/jbang#2515 — downstream test failures on macOS and Windows caused by this bug